### PR TITLE
Add ability to change behavior of ForceLog

### DIFF
--- a/pipeline/defaultlog_syslog.go
+++ b/pipeline/defaultlog_syslog.go
@@ -9,7 +9,7 @@ import (
 
 // ForceLog should rarely be used. It forceable logs an entry to the
 // Windows Event Log (on Windows) or to the SysLog (on Linux)
-func ForceLog(level LogLevel, msg string) {
+var ForceLog = func(level LogLevel, msg string) {
 	if defaultLogger == nil {
 		return // Return fast if we failed to create the logger.
 	}

--- a/pipeline/defaultlog_windows.go
+++ b/pipeline/defaultlog_windows.go
@@ -8,7 +8,7 @@ import (
 
 // ForceLog should rarely be used. It forceable logs an entry to the
 // Windows Event Log (on Windows) or to the SysLog (on Linux)
-func ForceLog(level LogLevel, msg string) {
+var ForceLog = func(level LogLevel, msg string) {
 	var el eventType
 	switch level {
 	case LogError, LogFatal, LogPanic:


### PR DESCRIPTION
In my project I don't need to write azure error logs to syslog. I suggest to define ForceLog as variable in order to be ability to change ForceLog behavior.