### PR TITLE
Add support for Plan 9

### DIFF
--- a/pipeline/defaultlog_plan9.go
+++ b/pipeline/defaultlog_plan9.go
@@ -1,0 +1,32 @@
+// +build plan9,!windows,!nacl,!linux
+
+package pipeline
+
+import (
+	"log"
+	"os"
+)
+
+// forceLog should rarely be used. It forceable logs an entry to the
+// Windows Event Log (on Windows) or to the SysLog (on Linux)
+func forceLog(level LogLevel, msg string) {
+	if defaultLogger == nil {
+		return // Return fast if we failed to create the logger.
+	}
+	// We are logging it, ensure trailing newline
+	if len(msg) == 0 || msg[len(msg)-1] != '\n' {
+		msg += "\n" // Ensure trailing newline
+	}
+	switch level {
+	case LogFatal:
+		defaultLogger.Fatal(msg)
+	case LogPanic:
+		defaultLogger.Panic(msg)
+	case LogError, LogWarning, LogInfo:
+		defaultLogger.Print(msg)
+	}
+}
+
+var defaultLogger = func() *log.Logger {
+	return log.New(os.Stderr, log.Prefix(), log.LstdFlags)
+}()


### PR DESCRIPTION
This PR adds support for the Plan 9 operating system as per `GOOS=plan9`. 

There is no central logging service on Plan 9, so logging to stderr is sufficient. 

Idiomatically in Plan 9 you'd see a user split out the stderr file descriptor to log to a separate file explicitly at the shell-level when calling the relevant program. 

